### PR TITLE
Support $count option

### DIFF
--- a/example-datasource/src/main/java/com/sdl/odata/example/datasource/InMemoryDataSourceProvider.java
+++ b/example-datasource/src/main/java/com/sdl/odata/example/datasource/InMemoryDataSourceProvider.java
@@ -22,6 +22,7 @@ import com.sdl.odata.api.processor.datasource.DataSource;
 import com.sdl.odata.api.processor.datasource.DataSourceProvider;
 import com.sdl.odata.api.processor.datasource.ODataDataSourceException;
 import com.sdl.odata.api.processor.query.QueryOperation;
+import com.sdl.odata.api.processor.query.QueryResult;
 import com.sdl.odata.api.processor.query.strategy.QueryOperationStrategy;
 import com.sdl.odata.api.service.ODataRequestContext;
 import com.sdl.odata.example.Person;
@@ -35,8 +36,6 @@ import java.util.List;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import static java.util.Collections.singletonList;
 
 /**
  * This is an example data source provide that uses in memory structures to demonstrate how to provide
@@ -62,7 +61,8 @@ public class InMemoryDataSourceProvider implements DataSourceProvider {
     @Override
     public QueryOperationStrategy getStrategy(ODataRequestContext oDataRequestContext, QueryOperation queryOperation, TargetType targetType) throws ODataException {
         StrategyBuilder builder = new StrategyBuilder();
-        List<Predicate<Person>> predicateList = builder.buildCriteria(queryOperation);
+        List<Predicate<Person>> predicateList = builder.buildCriteria(queryOperation, oDataRequestContext);
+
         int limit = builder.getLimit();
         int skip = builder.getSkip();
         List<String> propertyNames = builder.getPropertyNames();
@@ -71,30 +71,40 @@ public class InMemoryDataSourceProvider implements DataSourceProvider {
             LOG.debug("Executing query against in memory data");
             Stream<Person> personStream = inMemoryDataSource.getPersonConcurrentMap().values().stream();
 
-            Stream<Person> filteredStream = personStream.filter(p -> predicateList.stream()
-                    .allMatch(f -> f.test(p)));
+            List<Person> filteredPersons = personStream.filter(p -> predicateList.stream()
+                    .allMatch(f -> f.test(p))).collect(Collectors.toList());
 
-            if (builder.isCount()) {
-                long count = filteredStream.count();
+            long count = 0;
+            if (builder.isCount() || builder.includeCount()) {
+                count = filteredPersons.size();
                 LOG.debug("Counted {} persons matching query", count);
 
-                return singletonList(count);
+                if (builder.isCount()) {
+                    return QueryResult.from(count);
+                }
             }
 
-            List<Person> filteredPersons = filteredStream.skip(skip).limit(limit).collect(Collectors.toList());
+            if (skip != 0 || limit != Integer.MAX_VALUE) {
+                filteredPersons = filteredPersons.stream().skip(skip).limit(limit).collect(Collectors.toList());
+            }
+
             LOG.debug("Found {} persons matching query", filteredPersons.size());
 
             if (propertyNames != null && !propertyNames.isEmpty()) {
                 try {
                     LOG.debug("Selecting {} properties of person", propertyNames);
-                    return singletonList(EdmUtil.getEdmPropertyValue(filteredPersons.get(0), propertyNames.get(0)));
+                    return QueryResult.from(EdmUtil.getEdmPropertyValue(filteredPersons.get(0), propertyNames.get(0)));
                 } catch (IllegalAccessException e) {
                     LOG.error(e.getMessage(), e);
-                    return Collections.emptyList();
+                    return QueryResult.from(Collections.emptyList());
                 }
             }
 
-            return filteredPersons;
+            QueryResult result = QueryResult.from(filteredPersons);
+            if (builder.includeCount()) {
+                result = result.withCount(count);
+            }
+            return result;
         };
     }
 }


### PR DESCRIPTION
If $count=true specified in URI, we count entities before $top and $skip
applied to pass along with QueryResult.
